### PR TITLE
Instrument and trace only pointer calls

### DIFF
--- a/examples/pointer_call.c
+++ b/examples/pointer_call.c
@@ -1,0 +1,22 @@
+int foo(int i) {
+    if (0);
+    return i;
+}
+
+int (*ptr)(int) = *foo;
+
+typedef int (*function_ptr)(int);
+
+function_ptr meta (void) {
+    if (1);
+    return ptr;
+}
+
+int main(void) {
+    ptr(1);
+    ptr(ptr(1));
+    foo(ptr(1));
+    ptr(foo(1));
+    meta()(1);
+    meta()(foo(1));
+}

--- a/examples/pointer_call.c
+++ b/examples/pointer_call.c
@@ -1,5 +1,5 @@
 int foo(int i) {
-    if (0);
+    if (0) /* nothing here */;
     return i;
 }
 
@@ -8,7 +8,7 @@ int (*ptr)(int) = *foo;
 typedef int (*function_ptr)(int);
 
 function_ptr meta (void) {
-    if (1);
+    if (1) /* nothing here */;
     return ptr;
 }
 

--- a/include/src_tracer/_after_instrument.h
+++ b/include/src_tracer/_after_instrument.h
@@ -531,7 +531,10 @@ static inline __attribute__((always_inline)) long long int _is_retrace_switch(lo
 extern bool _trace_pointer_call;
 
 #define _TRACE_FUNC_INIT \
-    bool _trace_local_return = 0;
+    bool _trace_local_return __attribute__((unused)) = 0;
+
+#define _TRACE_POINTER_CALL_SET \
+    _trace_pointer_call = 1;
 
 #define _TRACE_POINTER_CALL_RESET \
     _trace_pointer_call = 0; \
@@ -541,18 +544,19 @@ extern bool _trace_pointer_call;
 #define _TRACE_RETURN_CHECK _trace_local_return
 
 #define _TRACE_POINTER_CALL(call) ({ \
-    _trace_pointer_call = 1; \
+    _TRACE_POINTER_CALL_SET; \
     call; \
 })
 #define _TRACE_POINTER_CALL_AFTER(type, call) ({ \
     type _trace_call_tmp = call; \
-    _trace_pointer_call = 1; \
+    _TRACE_POINTER_CALL_SET; \
     _trace_call_tmp; \
 })
 
 #else
 #define _TRACE_FUNC_INIT /* nothing here */
 #define _TRACE_CALL_CHECK 1
+#define _TRACE_POINTER_CALL_SET /* nothing here */
 #define _TRACE_POINTER_CALL_RESET /* nothing here */
 #define _TRACE_POINTER_CALL(call) call
 #define _TRACE_POINTER_CALL_AFTER(type, call) call
@@ -590,7 +594,7 @@ extern bool _trace_pointer_call;
 #define _TRY_END            _IS_RETRACE(_RETRACE_TRY_END(), _TRACE_TRY_END())
 #define _SETJMP(stmt)       _IS_RETRACE(_RETRACE_SETJMP(stmt), _TRACE_SETJMP(stmt))
 
-#define _TRACE_OPEN(fname)  _IS_RETRACE( ,_trace_open((fname)))
+#define _TRACE_OPEN(fname)  _TRACE_POINTER_CALL_SET; _IS_RETRACE( ,_trace_open((fname)))
 #define _TRACE_CLOSE        _IS_RETRACE(_RETRACE_END() ,_trace_close())
 
 #define _POINTER_CALL(call) _TRACE_POINTER_CALL(call)
@@ -621,7 +625,7 @@ extern bool _trace_pointer_call;
 #define _LOOP_BODY(id)      ;_TRACE_IF();
 #define _LOOP_END(id)       ;_TRACE_ELSE();
 
-#define _TRACE_OPEN(fname)  ;_trace_open((fname));
+#define _TRACE_OPEN(fname)  _TRACE_POINTER_CALL_SET; _trace_open((fname));
 #define _TRACE_CLOSE        ;_trace_close();
 
 #define _FORK(fork_stmt)    (_trace_before_fork(), \
@@ -691,7 +695,7 @@ extern bool _trace_pointer_call;
 #define _TRY_END            ;_RETRACE_TRY_END();
 #define _SETJMP(stmt)       _RETRACE_SETJMP(stmt)
 
-#define _TRACE_OPEN(fname)  /* nothing here */
+#define _TRACE_OPEN(fname)  ;_TRACE_POINTER_CALL_SET;
 #define _TRACE_CLOSE        ;_RETRACE_END();
 
 #define _FORK(fork_stmt)    (_retrace_elem('G', _retrace_fork_count), \
@@ -771,7 +775,7 @@ extern bool _trace_pointer_call;
 
 #define _SETJMP(stmt)       _RETRACE_SETJMP_CBMC(stmt)
 
-#define _TRACE_OPEN(fname)  ;retrace_i = 0;
+#define _TRACE_OPEN(fname)  ;_TRACE_POINTER_CALL_SET; retrace_i = 0;
 #define _TRACE_CLOSE        ;_RETRACE_END_CBMC();
 
 #define _FORK(fork_stmt)    fork_stmt

--- a/include/src_tracer/_after_instrument.h
+++ b/include/src_tracer/_after_instrument.h
@@ -591,7 +591,15 @@ static inline __attribute__((always_inline)) long long int _is_retrace_switch(lo
 #define _TRY_END            ;_TRACE_TRY_END();
 #define _SETJMP(stmt)       _TRACE_SETJMP(stmt)
 
-#define _POINTER_CALL(call) ({ _trace_pointer_call = 1; call ; })
+#define _POINTER_CALL(call) ({ \
+    _trace_pointer_call = 1; \
+    call; \
+})
+#define _POINTER_CALL_AFTER(type, call) ({ \
+    type _trace_call_tmp = call; \
+    _trace_pointer_call = 1; \
+    _trace_call_tmp; \
+})
 
 #define _RETRO_ONLY(code)   /* nothing here */
 #define _RETRO_SKIP(code)   code
@@ -655,7 +663,15 @@ static inline __attribute__((always_inline)) long long int _is_retrace_switch(lo
 #define _FORK(fork_stmt)    (_retrace_elem('G', _retrace_fork_count), \
                              _retrace_after_fork(fork_stmt))
 
-#define _POINTER_CALL(call) ({ _trace_pointer_call = 1; call ; })
+#define _POINTER_CALL(call) ({ \
+    _trace_pointer_call = 1; \
+    call; \
+})
+#define _POINTER_CALL_AFTER(type, call) ({ \
+    type _trace_call_tmp = call; \
+    _trace_pointer_call = 1; \
+    _trace_call_tmp; \
+})
 
 #define _RETRO_ONLY(code)   code
 #define _RETRO_SKIP(code)   /* nothing here */
@@ -752,7 +768,8 @@ static inline __attribute__((always_inline)) long long int _is_retrace_switch(lo
 #define _TRY_END            /* nothing here */
 #define _SETJMP(setjmp_stmt) setjmp_stmt
 
-#define _POINTER_CALL(call) /* nothing here */
+#define _POINTER_CALL(call) call
+#define _POINTER_CALL_AFTER(type, call) call
 
 #define _RETRO_ONLY(code)   /* nothing here */
 #define _RETRO_SKIP(code)   code

--- a/instrumenter.py
+++ b/instrumenter.py
@@ -10,33 +10,37 @@ from src_tracer.database import Database
 # arguments
 ap = argparse.ArgumentParser()
 ap.add_argument("filename",
-                help="pre-preccessed C or C++ file to instrument")
+                help="Pre-preccessed C or C++ file to instrument.")
 ap.add_argument("store_dir", nargs='?',
-                help="where to store database and traces")
+                help="Where to store database and traces.")
 ap.add_argument("--database",
-                help="custom database path")
+                help="Custom database path.")
 ap.add_argument("--no-return", action='store_true',
-                help="do not instrument returns")
+                help="Do not instrument returns.")
 ap.add_argument("--switch-number", action='store_true',
-                help="instrument to record switch number instead of case based bit-tracing")
+                help="Instrument to record switch number instead of case based bit-tracing.")
 ap.add_argument("--short-circuit", action='store_true',
-                help="instrument short circuit operators (experimental)")
+                help="Instrument short circuit operators (experimental).")
 ap.add_argument("--no-inner", action='store_true',
-                help="do not instrument any control structrure including if, else, while, for")
+                help="Do not instrument any control structrure including if, else, while, for.")
 ap.add_argument("--inline", action='store_true',
-                help="instrument inline function calls and returns")
+                help="Instrument inline function calls and returns.")
 ap.add_argument("--no-main", action='store_true',
-                help="do not instrument the main function to start trace recording")
+                help="Do not instrument the main function to start trace recording.")
 ap.add_argument("--record",
-                help="start trace recording in other function than main (implies --no-main)")
+                help="Start trace recording in other function than main (implies --no-main).")
 ap.add_argument("--no-close", action='store_true',
-                help="do not stop trace recording in main (or other) function")
+                help="Do not stop trace recording in main (or other) function.")
 ap.add_argument("--anon", action='store_true',
-                help="instrument all functions without a number")
+                help="Instrument all functions without a number.")
 ap.add_argument("--no-functions", action='store_true',
-                help="do not instrument functions at all")
+                help="Do not instrument functions at all.")
 ap.add_argument("--no-calls", action='store_true',
-                help="do not instrument any calls, currently we instrument only fork() and setjmp()")
+                help="Do not instrument any calls. "
+                "Currently we instrument exit() and friends, fork() and setjmp().")
+ap.add_argument("--pointer-calls", action='store_true',
+                help="Instrument pointer calls. "
+                "Note that you have to compile your sources with -D_TRACE_POINTER_CALLS_ONLY to make use of it!")
 args = ap.parse_args()
 
 # trace store dir
@@ -69,7 +73,7 @@ instrumenter = Instrumenter(database, store_dir, case_instrument=not args.switch
                             main_instrument=main_instrument, main_spelling=main_spelling, main_close=not args.no_close,
                             anon_instrument=args.anon,
                             function_instrument=not args.no_functions, inner_instrument=not args.no_inner,
-                            call_instrument=not args.no_calls)
+                            call_instrument=not args.no_calls, pointer_call_instrument=args.pointer_calls)
 instrumenter.parse(args.filename)
 instrumenter.annotate_all(args.filename)
 database.close_connection()

--- a/lib/src_tracer.c
+++ b/lib/src_tracer.c
@@ -124,7 +124,6 @@ void _trace_open(const char *fname) {
     trace_fd = fd;
     _trace_buf_pos = 0;
     _trace_ie_byte = _TRACE_IE_BYTE_INIT;
-    _trace_pointer_call = true;
 }
 
 void _trace_before_fork(void) {

--- a/lib/src_tracer.c
+++ b/lib/src_tracer.c
@@ -28,6 +28,7 @@ static int temp_trace_buf_pos;
 static int temp_trace_fd;
 
 unsigned long long int _trace_setjmp_idx;
+bool _trace_pointer_call;
 
 #ifndef _TRACE_USE_POSIX_WRITE
 // taken from musl (arch/x86_64/syscall_arch.h)
@@ -123,6 +124,7 @@ void _trace_open(const char *fname) {
     trace_fd = fd;
     _trace_buf_pos = 0;
     _trace_ie_byte = _TRACE_IE_BYTE_INIT;
+    _trace_pointer_call = true;
 }
 
 void _trace_before_fork(void) {

--- a/src_tracer/instrumenter.py
+++ b/src_tracer/instrumenter.py
@@ -408,6 +408,34 @@ class Instrumenter:
             self.add_annotation(b"_SWITCH(", switch_num.extent.start)
             self.add_annotation(b")", switch_num.extent.end, 1)
 
+    def is_pointer_call(self, node):
+        childs = [c for c in node.get_children()]
+        normal_call = False
+        if len(childs) > 0:
+            unexp = childs[0]
+            childs = [c for c in unexp.get_children()]
+            if len(childs) > 0 and childs[0].kind == CursorKind.DECL_REF_EXPR:
+                reference = childs[0]
+                target = reference.referenced
+                if target and target.kind == CursorKind.FUNCTION_DECL:
+                    normal_call = True
+        return not normal_call
+
+    def last_call_before(self, node):
+        # Returns the last child node (if any) of kind CALL_EXPR that would be
+        # evaluated before the evaluation of the current node.
+        # Otherwise it returns None.
+        childs = [c for c in node.get_children()]
+        for c in reversed(childs):
+            if c.kind == CursorKind.CALL_EXPR:
+                return c
+            rec_last = self.last_call_before(c)
+            if rec_last is not None:
+                return rec_last
+        return None
+
+    last_calls = []
+
     def visit_call(self, node):
         # Some calls need to be anotated
         if node.spelling == "fork":
@@ -418,23 +446,18 @@ class Instrumenter:
             self.prepent_annotation(b")", node.extent.end)
         elif node.spelling in ("exit", "_Exit", "_exit"):
             self.add_annotation(b"(({int exitcode = ", node.extent.start, len(node.spelling))
-            self.add_annotation(b"; _TRACE_CLOSE; exitcode; }))", node.extent.end)
+            self.prepent_annotation(b"; _TRACE_CLOSE; exitcode; }))", node.extent.end)
         elif node.spelling == "abort":
             self.add_annotation(b"_TRACE_CLOSE ", node.extent.start)
-        else:
-            # check for pointer call
-            childs = [c for c in node.get_children()]
-            normal_call = False
-            if len(childs) > 0:
-                unexp = childs[0]
-                childs = [c for c in unexp.get_children()]
-                if len(childs) > 0 and childs[0].kind == CursorKind.DECL_REF_EXPR:
-                    ref = childs[0].referenced
-                    if ref and ref.kind == CursorKind.FUNCTION_DECL:
-                        normal_call = True
-            if not normal_call:
+        elif self.is_pointer_call(node):
+            last_call = self.last_call_before(node)
+            if last_call is None:
                 self.add_annotation(b"_POINTER_CALL(", node.extent.start)
                 self.prepent_annotation(b")", node.extent.end)
+            else:
+                last_call_type = bytes(last_call.type.spelling, "utf-8")
+                self.prepent_annotation(b"_POINTER_CALL_AFTER(" + last_call_type + b", ", last_call.extent.start)
+                self.add_annotation(b")", last_call.extent.end)
 
     def visit_try(self, node):
         childs = [c for c in node.get_children()]

--- a/src_tracer/instrumenter.py
+++ b/src_tracer/instrumenter.py
@@ -412,6 +412,20 @@ class Instrumenter:
             self.add_annotation(b"; _TRACE_CLOSE; exitcode; }))", node.extent.end)
         elif node.spelling == "abort":
             self.add_annotation(b"_TRACE_CLOSE ", node.extent.start)
+        else:
+            # check for pointer call
+            childs = [c for c in node.get_children()]
+            normal_call = False
+            if len(childs) > 0:
+                unexp = childs[0]
+                childs = [c for c in unexp.get_children()]
+                if len(childs) > 0 and childs[0].kind == CursorKind.DECL_REF_EXPR:
+                    ref = childs[0].referenced
+                    if ref and ref.kind == CursorKind.FUNCTION_DECL:
+                        normal_call = True
+            if not normal_call:
+                self.add_annotation(b"_POINTER_CALL(", node.extent.start)
+                self.prepent_annotation(b")", node.extent.end)
 
     def visit_try(self, node):
         childs = [c for c in node.get_children()]

--- a/src_tracer/instrumenter.py
+++ b/src_tracer/instrumenter.py
@@ -10,7 +10,7 @@ class Instrumenter:
     def __init__(self, database, trace_store_dir, case_instrument=False, boolop_instrument=False,
                  return_instrument=True, inline_instrument=False, main_instrument=True, main_spelling="main",
                  main_close=False, anon_instrument=False,
-                 function_instrument=True, inner_instrument=True, call_instrument=True):
+                 function_instrument=True, inner_instrument=True, call_instrument=True, pointer_call_instrument=False):
         """
         Instrument a C compilation unit (pre-processed C source code).
         :param case_instrument: instrument each switch case, not the switch (experimental)
@@ -28,6 +28,7 @@ class Instrumenter:
         self.function_instrument = function_instrument
         self.inner_instrument = inner_instrument
         self.call_instrument = call_instrument
+        self.pointer_call_instrument = pointer_call_instrument
 
         self.ifs = []
         self.loops = []
@@ -449,7 +450,7 @@ class Instrumenter:
             self.prepent_annotation(b"; _TRACE_CLOSE; exitcode; }))", node.extent.end)
         elif node.spelling == "abort":
             self.add_annotation(b"_TRACE_CLOSE ", node.extent.start)
-        elif self.is_pointer_call(node):
+        elif self.pointer_call_instrument and self.is_pointer_call(node):
             last_call = self.last_call_before(node)
             if last_call is None:
                 self.add_annotation(b"_POINTER_CALL(", node.extent.start)


### PR DESCRIPTION
Solves #36.

Now approach to instrument pointer calls. The instrumenter inserts `_POINTER_CALL(call)` around such calls. Then the tracer ignores `_FUNC(num)` except that we had a `_POINTER_CALL()`.

*Example:*

```C
foo( x );
void (*fun)(int) = foo;
fun( x );
mystruct->myfun( x );
metafun( y ) ( x );
fun( random() );
```

*Instrumented:* with `instrumenter.py FILENAME --pointer-calls`

```C
foo( x );
void (*fun)(int) = foo;
_POINTER_CALL(fun( x ));
_POINTER_CALL(mystruct->myfun( x ));
_POINTER_CALL_AFTER(metafun( y )) ( x );
fun( _POINTER_CALL_AFTER(random()) );
```

*Note:* To make use of it when tracing/retracing, compile with `-D_TRACE_POINTER_CALLS_ONLY`! Then we trace only function numbers for pointer calls. Otherwise the macros will be without effect and every function number gets traced.

*Technical details:* The clang.cindex, well, does not exactly expose pointer calls. But it is possible to indirectly detect "normal" function calls, by checking if they reference a `CursorKind.FUNCTION_DECL`. Otherwise, it would reference for example a `CursorKind.VAR_DECL` or to a member in a struct. Or if you use pointer-arithmetic, there could be no reference at all.

When in trace mode, `_POINTER_CALL(...)` sets a global variable `_trace_pointer_call` to true. `_FUNC(num)` is only active when this variable is true. After `_FUNC(num)` is done, `_trace_pointer_call` is set to false again. Since the pointer and function arguments are evaluated before the call, we use the `_POINTER_CALL_AFTER(other_call)` in these situtations instead, to set `_trace_pointer_call` only after the other call finished.