### PR TITLE
alternative letter names that make more sense

### DIFF
--- a/include/src_tracer/_after_instrument.h
+++ b/include/src_tracer/_after_instrument.h
@@ -85,28 +85,25 @@ extern int _trace_buf_pos;
  #define _TRACE_SET_IS_ELEM         0b01000000
 
 #define _TRACE_TEST_ELEM            0b11111111
- #define _TRACE_SET_END             0b01000101 // 'E'
- #define _TRACE_SET_RETURN          0b01010010 // 'R'
- #define _TRACE_SET_RETURN_TAIL     0b01001000 // 'H'
- #define _TRACE_SET_FUNC_ANON       0b01000001 // 'A'
- #define _TRACE_SET_TRY             0b01010011 // 'S'
- #define _TRACE_SET_UNTRY           0b01010101 // 'U'
- #define _TRACE_SET_PAUSE           0b01010000 // 'P'
+ #define _TRACE_SET_END             'Q'
+ #define _TRACE_SET_RETURN          'R'
+ #define _TRACE_SET_RETURN_TAIL     'S'
+ #define _TRACE_SET_FUNC_ANON       'A'
+ #define _TRACE_SET_TRY             'T'
+ #define _TRACE_SET_UNTRY           'U'
+ #define _TRACE_SET_PAUSE           'P'
 /* FUNC_32 always comes with 32 bit function number */
- #define _TRACE_SET_FUNC_32         0b01000110 // 'F'
-/* 'T' and 'N' could be used instead of
+ #define _TRACE_SET_FUNC_32         'C'
+/* 'I' and 'O' could be used instead of
  * _TRACE_IE_BYTE_INIT for faster trace writing */
- #define _TRACE_SET_IF              0b01010100 // 'T'
- #define _TRACE_SET_ELSE            0b01001110 // 'N'
-/* 'G' is reserved, use _TRACE_SET_FORK */
- #define _TRACE_SET_FORK_reserved   0b01000111 // 'G'
-/* 'L' is reserved, use _TRACE_SET_CATCH */
- #define _TRACE_SET_CATCH_reserved  0b01001100 // 'L'
+ #define _TRACE_SET_IF              'I'
+ #define _TRACE_SET_ELSE            'O'
+/* 'F' is reserved, use _TRACE_SET_FORK */
+ #define _TRACE_SET_FORK_reserved   'F'
+/* 'E' is reserved, use _TRACE_SET_CATCH */
+ #define _TRACE_SET_CATCH_reserved  'E'
 /* 'D' is reserved, use _TRACE_SET_DATA */
- #define _TRACE_SET_DATA_reserved   0b01000100 // 'D'
-/* 'M' and 'B' are currently not supported */
- #define _TRACE_SET_FUNC_STRING_res 0b01001101 // 'M'
- #define _TRACE_SET_DATA_STRING_res 0b01000010 // 'B'
+ #define _TRACE_SET_DATA_reserved   'D'
 
 /* 'X' to '_' are reserved */
 #define _TRACE_TEST_ELEM_reserved   0b11111000
@@ -144,8 +141,8 @@ extern int _trace_buf_pos;
 
 #ifdef BYTE_TRACE
 
-#define _TRACE_IF()     _TRACE_PUT('T')
-#define _TRACE_ELSE()   _TRACE_PUT('N')
+#define _TRACE_IF()     _TRACE_PUT('I')
+#define _TRACE_ELSE()   _TRACE_PUT('O')
 #define _TRACE_IE_FINISH
 #define _TRACE_IE(if_true) \
     if (if_true) { \
@@ -320,9 +317,9 @@ extern int _trace_buf_pos;
 #define _TRACE_CASE_TEXT(num, bit_cnt) ; \
     for (int i = bit_cnt-1; i >= 0; i--) { \
         if (num & (1 << i)) { \
-            _TRACE_PUT_TEXT('T'); \
+            _TRACE_PUT_TEXT('I'); \
         } else { \
-            _TRACE_PUT_TEXT('N'); \
+            _TRACE_PUT_TEXT('O'); \
         } \
     }
 
@@ -388,9 +385,9 @@ static inline __attribute__((always_inline)) bool _trace_condition(bool cond) {
 
 static inline __attribute__((always_inline)) bool _text_trace_condition(bool cond) {
     if (cond) {
-        _TRACE_PUT_TEXT('T');
+        _TRACE_PUT_TEXT('I');
     } else {
-        _TRACE_PUT_TEXT('N');
+        _TRACE_PUT_TEXT('O');
     }
     return cond;
 }
@@ -411,7 +408,7 @@ extern volatile int _retrace_fork_count;
 
 #define _RETRACE_FUNC(num) \
     if (_TRACE_CALL_CHECK) { \
-        _RETRACE_ELEM('F', num); \
+        _RETRACE_ELEM('C', num); \
         _TRACE_POINTER_CALL_RESET; \
     }
 
@@ -421,19 +418,19 @@ extern volatile int _retrace_fork_count;
     }
 
 #define _RETRACE_IF() \
-    _RETRACE_ELEM('T', 0)
+    _RETRACE_ELEM('I', 0)
 
 #define _RETRACE_ELSE() \
-    _RETRACE_ELEM('N', 0)
+    _RETRACE_ELEM('O', 0)
 
 #define _RETRACE_END() \
-    _RETRACE_ELEM('E', 0)
+    _RETRACE_ELEM('Q', 0)
 
 #define _RETRACE_TRY() \
-    _RETRACE_ELEM('S', 0)
+    _RETRACE_ELEM('T', 0)
 
 #define _RETRACE_CATCH(cur_idx) { \
-    _RETRACE_ELEM('L', _trace_setjmp_idx - (cur_idx)); \
+    _RETRACE_ELEM('E', _trace_setjmp_idx - (cur_idx)); \
     /* _trace_setjmp_idx = cur_idx; */ \
 }
 
@@ -464,9 +461,9 @@ static inline __attribute__((always_inline)) long long int _retrace_elem(char ty
 
 static inline __attribute__((always_inline)) bool _retrace_condition(bool cond) {
     if (cond) {
-        _retrace_letter = 'T';
+        _retrace_letter = 'I';
     } else {
-        _retrace_letter = 'N';
+        _retrace_letter = 'O';
     }
     _retrace_num = 0;
     _retrace_breakpoint();
@@ -475,9 +472,9 @@ static inline __attribute__((always_inline)) bool _retrace_condition(bool cond) 
 
 static inline __attribute__((always_inline)) int _retrace_after_fork(int fork_val) {
     if (fork_val != 0) {
-        _retrace_letter = 'T';
+        _retrace_letter = 'I';
     } else {
-        _retrace_letter = 'N';
+        _retrace_letter = 'O';
     }
     _retrace_num = 0;
     _retrace_breakpoint();
@@ -611,7 +608,7 @@ extern bool _trace_pointer_call;
 #define _CONDITION(cond)    _is_retrace_condition(cond)
 #define _FUNC(num)          _TRACE_FUNC_INIT; _IS_RETRACE(_RETRACE_FUNC(num), _TRACE_FUNC(num))
 #define _FUNC_RETURN        _IS_RETRACE(_RETRACE_RETURN('R'), _TRACE_RETURN(_TRACE_SET_RETURN))
-#define _FUNC_RETURN_TAIL   _IS_RETRACE(_RETRACE_RETURN('H'), _TRACE_RETURN(_TRACE_SET_RETURN_TAIL))
+#define _FUNC_RETURN_TAIL   _IS_RETRACE(_RETRACE_RETURN('S'), _TRACE_RETURN(_TRACE_SET_RETURN_TAIL))
 // non-macro version for switch
 #define _SWITCH(num)        _is_retrace_switch(num)
 // bit-trace version for switch
@@ -683,12 +680,12 @@ extern bool _trace_pointer_call;
 #elif defined _TEXT_TRACE_MODE
 /* text trace mode, experimental */
 
-#define _IF                 ;_TRACE_PUT_TEXT('T');
-#define _ELSE               ;_TRACE_PUT_TEXT('N');
+#define _IF                 ;_TRACE_PUT_TEXT('I');
+#define _ELSE               ;_TRACE_PUT_TEXT('O');
 #define _CONDITION(cond)    _text_trace_condition(cond)
-#define _FUNC(num)          ;_TRACE_NUM_TEXT('F', ((unsigned int)(num)));
+#define _FUNC(num)          ;_TRACE_NUM_TEXT('C', ((unsigned int)(num)));
 #define _FUNC_RETURN        ;_TRACE_PUT_TEXT('R');
-#define _FUNC_RETURN_TAIL   ;_TRACE_PUT_TEXT('H');
+#define _FUNC_RETURN_TAIL   ;_TRACE_PUT_TEXT('S');
 // non-macro version for switch
 #define _SWITCH(num)        _trace_num_text('D', ((unsigned int)(num)))
 // experimental version for switch
@@ -698,8 +695,8 @@ extern bool _trace_pointer_call;
                                 _cflow_switch_##id = 0; \
                             };
 #define _LOOP_START(id)     /* nothing here */
-#define _LOOP_BODY(id)      ;_TRACE_PUT_TEXT('T');
-#define _LOOP_END(id)       ;_TRACE_PUT_TEXT('N');
+#define _LOOP_BODY(id)      ;_TRACE_PUT_TEXT('I');
+#define _LOOP_END(id)       ;_TRACE_PUT_TEXT('O');
 
 #define _TRACE_OPEN(fname)  ;_trace_open(fname ".txt");
 #define _TRACE_CLOSE        ;_trace_close();
@@ -716,7 +713,7 @@ extern bool _trace_pointer_call;
 #define _CONDITION(cond)    _retrace_condition(cond)
 #define _FUNC(num)          _TRACE_FUNC_INIT; _RETRACE_FUNC(num);
 #define _FUNC_RETURN        ;_RETRACE_RETURN('R');
-#define _FUNC_RETURN_TAIL   ;_RETRACE_RETURN('H');
+#define _FUNC_RETURN_TAIL   ;_RETRACE_RETURN('S');
 // non-macro version for switch
 #define _SWITCH(num)        _retrace_elem('D', num)
 // bit-trace version for switch
@@ -737,7 +734,7 @@ extern bool _trace_pointer_call;
 #define _TRACE_OPEN(fname)  ;_TRACE_POINTER_CALL_SET;
 #define _TRACE_CLOSE        ;_RETRACE_END();
 
-#define _FORK(fork_stmt)    (_retrace_elem('G', _retrace_fork_count), \
+#define _FORK(fork_stmt)    (_retrace_elem('F', _retrace_fork_count), \
                              _retrace_after_fork(fork_stmt))
 
 #define _POINTER_CALL(call) _TRACE_POINTER_CALL(call)
@@ -761,14 +758,14 @@ extern bool _trace_pointer_call;
 #define _RETRACE_CASE_CBMC(num, bit_cnt) ; \
     for (int i = bit_cnt-1; i >= 0; i--) { \
         if (num & (1 << i)) { \
-            _RETRACE_CBMC('T', 0); \
+            _RETRACE_CBMC('I', 0); \
         } else { \
-            _RETRACE_CBMC('N', 0); \
+            _RETRACE_CBMC('O', 0); \
         } \
     }
 
 #define _RETRACE_END_CBMC() { \
-    _RETRACE_CBMC('E', 0); \
+    _RETRACE_CBMC('Q', 0); \
     __CPROVER_assume(retrace_i == retrace_arr_len); \
     /* now check all past assertions */ \
     for (int i = 0; i < _retrace_assert_idx; i++) { \
@@ -781,28 +778,28 @@ extern bool _trace_pointer_call;
 }
 
 #define _RETRACE_SETJMP_CBMC(setjmp_stmt) ({ \
-    _RETRACE_CBMC('S', 0); \
+    _RETRACE_CBMC('T', 0); \
     _trace_setjmp_idx ++; \
     int cur_setjmp_idx = _trace_setjmp_idx; \
     int setjmp_res = setjmp_stmt; \
     if (setjmp_res != 0) { \
-        _RETRACE_CBMC('L', _trace_setjmp_idx - cur_setjmp_idx); \
+        _RETRACE_CBMC('E', _trace_setjmp_idx - cur_setjmp_idx); \
     } \
     setjmp_res; \
 })
 
 #define _RETRACE_FUNC_CBMC(num) \
     if (_TRACE_CALL_CHECK) { \
-        _RETRACE_CBMC('F', num); \
+        _RETRACE_CBMC('C', num); \
         _TRACE_POINTER_CALL_RESET; \
     }
 
-#define _IF                 ;_RETRACE_CBMC('T', 0);
-#define _ELSE               ;_RETRACE_CBMC('N', 0);
+#define _IF                 ;_RETRACE_CBMC('I', 0);
+#define _ELSE               ;_RETRACE_CBMC('O', 0);
 #define _CONDITION(cond)    cond
 #define _FUNC(num)          _TRACE_FUNC_INIT; _RETRACE_FUNC_CBMC(num);
 #define _FUNC_RETURN        ;if(_TRACE_RETURN_CHECK) { _RETRACE_CBMC('R', 0); };
-#define _FUNC_RETURN_TAIL   ;if(_TRACE_RETURN_CHECK) { _RETRACE_CBMC('H', 0); };
+#define _FUNC_RETURN_TAIL   ;if(_TRACE_RETURN_CHECK) { _RETRACE_CBMC('S', 0); };
 #define _SWITCH(num)        ;_RETRACE_CBMC('D', num);
 #define _SWITCH_START(id,cnt) ;bool _cflow_switch_##id = 1;
 #define _CASE(num, id, cnt) ;if (_cflow_switch_##id) { \
@@ -810,8 +807,8 @@ extern bool _trace_pointer_call;
                                 _cflow_switch_##id = 0; \
                             };
 #define _LOOP_START(id)     /* nothing here */
-#define _LOOP_BODY(id)      ;_RETRACE_CBMC('T', 0);
-#define _LOOP_END(id)       ;_RETRACE_CBMC('N', 0);
+#define _LOOP_BODY(id)      ;_RETRACE_CBMC('I', 0);
+#define _LOOP_END(id)       ;_RETRACE_CBMC('O', 0);
 
 #define _SETJMP(stmt)       _RETRACE_SETJMP_CBMC(stmt)
 

--- a/include/src_tracer/_after_instrument.h
+++ b/include/src_tracer/_after_instrument.h
@@ -85,7 +85,7 @@ extern int _trace_buf_pos;
  #define _TRACE_SET_IS_ELEM         0b01000000
 
 #define _TRACE_TEST_ELEM            0b11111111
- #define _TRACE_SET_END             'L'
+ #define _TRACE_SET_END             'E'
  #define _TRACE_SET_RETURN          'R'
  #define _TRACE_SET_RETURN_TAIL     'S'
  #define _TRACE_SET_FUNC_ANON       'A'
@@ -100,8 +100,8 @@ extern int _trace_buf_pos;
  #define _TRACE_SET_ELSE            'O'
 /* 'F' is reserved, use _TRACE_SET_FORK */
  #define _TRACE_SET_FORK_reserved   'F'
-/* 'E' is reserved, use _TRACE_SET_CATCH */
- #define _TRACE_SET_CATCH_reserved  'E'
+/* 'J' is reserved, use _TRACE_SET_CATCH */
+ #define _TRACE_SET_CATCH_reserved  'J'
 /* 'D' is reserved, use _TRACE_SET_DATA */
  #define _TRACE_SET_DATA_reserved   'D'
 
@@ -424,13 +424,13 @@ extern volatile int _retrace_fork_count;
     _RETRACE_ELEM('O', 0)
 
 #define _RETRACE_END() \
-    _RETRACE_ELEM('L', 0)
+    _RETRACE_ELEM('E', 0)
 
 #define _RETRACE_TRY() \
     _RETRACE_ELEM('T', 0)
 
 #define _RETRACE_CATCH(cur_idx) { \
-    _RETRACE_ELEM('E', _trace_setjmp_idx - (cur_idx)); \
+    _RETRACE_ELEM('J', _trace_setjmp_idx - (cur_idx)); \
     /* _trace_setjmp_idx = cur_idx; */ \
 }
 
@@ -765,7 +765,7 @@ extern bool _trace_pointer_call;
     }
 
 #define _RETRACE_END_CBMC() { \
-    _RETRACE_CBMC('L', 0); \
+    _RETRACE_CBMC('E', 0); \
     __CPROVER_assume(retrace_i == retrace_arr_len); \
     /* now check all past assertions */ \
     for (int i = 0; i < _retrace_assert_idx; i++) { \
@@ -783,7 +783,7 @@ extern bool _trace_pointer_call;
     int cur_setjmp_idx = _trace_setjmp_idx; \
     int setjmp_res = setjmp_stmt; \
     if (setjmp_res != 0) { \
-        _RETRACE_CBMC('E', _trace_setjmp_idx - cur_setjmp_idx); \
+        _RETRACE_CBMC('J', _trace_setjmp_idx - cur_setjmp_idx); \
     } \
     setjmp_res; \
 })

--- a/include/src_tracer/_after_instrument.h
+++ b/include/src_tracer/_after_instrument.h
@@ -85,7 +85,7 @@ extern int _trace_buf_pos;
  #define _TRACE_SET_IS_ELEM         0b01000000
 
 #define _TRACE_TEST_ELEM            0b11111111
- #define _TRACE_SET_END             'Q'
+ #define _TRACE_SET_END             'L'
  #define _TRACE_SET_RETURN          'R'
  #define _TRACE_SET_RETURN_TAIL     'S'
  #define _TRACE_SET_FUNC_ANON       'A'
@@ -424,7 +424,7 @@ extern volatile int _retrace_fork_count;
     _RETRACE_ELEM('O', 0)
 
 #define _RETRACE_END() \
-    _RETRACE_ELEM('Q', 0)
+    _RETRACE_ELEM('L', 0)
 
 #define _RETRACE_TRY() \
     _RETRACE_ELEM('T', 0)
@@ -765,7 +765,7 @@ extern bool _trace_pointer_call;
     }
 
 #define _RETRACE_END_CBMC() { \
-    _RETRACE_CBMC('Q', 0); \
+    _RETRACE_CBMC('L', 0); \
     __CPROVER_assume(retrace_i == retrace_arr_len); \
     /* now check all past assertions */ \
     for (int i = 0; i < _retrace_assert_idx; i++) { \

--- a/print_trace.py
+++ b/print_trace.py
@@ -118,7 +118,7 @@ for elem in trace:
         setjmp_indent.pop()
         # print as usual
         print_extra(elem.pretty(show_pos=args.show_pos))
-    elif elem.letter == 'E':
+    elif elem.letter == 'J':
         # longjmp, catch
         # restore indent
         indent = setjmp_indent[-elem.num -1]

--- a/print_trace.py
+++ b/print_trace.py
@@ -98,16 +98,16 @@ if args.pretty == -1:
 setjmp_indent = []
 
 for elem in trace:
-    if elem.letter == 'T' or elem.letter == 'N':
+    if elem.letter == 'I' or elem.letter == 'O':
         print_with_count(f"{elem.letter}")
-    elif elem.letter in ('R', 'H'):
+    elif elem.letter in ('R', 'S'):
         indent -= 1
         print_extra(elem.pretty(show_pos=args.show_pos))
     elif elem.letter == 'A':
         # anonymous function call
         print_extra(elem.pretty(show_pos=args.show_pos))
         indent += 1
-    elif elem.letter == 'S':
+    elif elem.letter == 'T':
         # setjmp, try
         # save current indent
         setjmp_indent.append(indent)
@@ -118,7 +118,7 @@ for elem in trace:
         setjmp_indent.pop()
         # print as usual
         print_extra(elem.pretty(show_pos=args.show_pos))
-    elif elem.letter == 'L':
+    elif elem.letter == 'E':
         # longjmp, catch
         # restore indent
         indent = setjmp_indent[-elem.num -1]
@@ -128,7 +128,7 @@ for elem in trace:
         print_extra(elem.pretty(show_pos=args.show_pos))
     else:
         num = elem.num
-        if elem.letter == 'F':
+        if elem.letter == 'C':
             if args.pretty in (5,3):
                 name = database.get_name(num)
                 # All upper case letters in the trace are treated as elem,

--- a/src_tracer/instrumenter.py
+++ b/src_tracer/instrumenter.py
@@ -143,15 +143,21 @@ class Instrumenter:
         for ret_stmt in node.walk_preorder():
             if ret_stmt.kind == CursorKind.RETURN_STMT:
                 if self.is_expr_only(ret_stmt):
+                    self.add_annotation(b"{ ", ret_stmt.extent.start)
                     if ret:
                         self.add_annotation(b"_FUNC_RETURN ", ret_stmt.extent.start)
                     if close:
                         self.add_annotation(b"_TRACE_CLOSE ", ret_stmt.extent.start)
+                    semi_off = self.find_next_semi(ret_stmt.extent.end)
+                    self.prepent_annotation(b" }", ret_stmt.extent.end, semi_off + 1)
                 elif self.assume_tailcall:
+                    self.add_annotation(b"{ ", ret_stmt.extent.start)
                     if ret:
                         self.add_annotation(b"_FUNC_RETURN_TAIL ", ret_stmt.extent.start)
                     if close:
                         self.add_annotation(b"_TRACE_CLOSE ", ret_stmt.extent.start)
+                    semi_off = self.find_next_semi(ret_stmt.extent.end)
+                    self.prepent_annotation(b" }", ret_stmt.extent.end, semi_off + 1)
                 else:
                     childs = [c for c in ret_stmt.get_children()]
                     ret_expr = childs[0]

--- a/src_tracer/retrace.py
+++ b/src_tracer/retrace.py
@@ -266,7 +266,7 @@ class SourceTraceReplayer:
             simgr.merge(stash=stash)
 
     def try_solve_unconstrained(self, elem, simgr, database, to_stash='active'):
-        if elem.letter == 'F' and database:
+        if elem.letter == 'C' and database:
             fun_num = elem.num
             try:
                 fun_name = database.get_name(fun_num)
@@ -286,7 +286,7 @@ class SourceTraceReplayer:
         # function name not given?
         if not func_name:
             elem = next(iter(trace))
-            if elem.letter != 'F':
+            if elem.letter != 'C':
                 raise ValueError(f'Trace contains first element "{elem.letter}"')
             func_num = elem.num
             func_name = database.get_name(func_num)
@@ -372,7 +372,7 @@ class SourceTraceReplayer:
                 name = None
                 if not elem.bs == b'':
                     num = elem.num
-                    if elem.letter == 'F' and database:
+                    if elem.letter == 'C' and database:
                         name = database.get_name(num)
                 if len(simgr.traced) > 1:
                     log.debug(elem.pretty(name=name) + f" (found {len(simgr.traced)})")

--- a/src_tracer/retrace.py
+++ b/src_tracer/retrace.py
@@ -338,17 +338,12 @@ class SourceTraceReplayer:
                 while simgr.active != []:
                     simgr.explore(find=find, avoid=avoid, find_stash='traced')
 
-                # PART 2.5: handle unconstrained
+                # PART 3: handle unconstrained
                 if simgr.unconstrained != []:
                     self.try_solve_unconstrained(elem, simgr, database)
-                    # to break out of PART 2 loop if try_solve failed
+                    # to break out of PART 3 loop if try_solve failed
                     simgr.move(from_stash='unconstrained', to_stash='deadended')
-                    # final check is in PART 3
-
-            # PART 3: nothing found?
-            if simgr.traced == []:
-                log.warning("Could not find %s at all in simgr %s", elem.letter, simgr)
-                return (simgr, state)
+                    # final check is in PART 6
 
             # PART 4: merge states
             self.merge(simgr, 'traced', merging)
@@ -362,19 +357,24 @@ class SourceTraceReplayer:
                 state.solver.add(mem_int == trace_int)
                 state.solver.add(mem_letter == trace_letter)
 
-            # PART 6: drop all states not in traced
+            # PART 6: nothing found?
+            if simgr.traced == []:
+                log.warning("Could not find %s at all in simgr %s", elem.letter, simgr)
+                return (simgr, state)
+
+            # PART 7: drop all states not in traced
             simgr.drop(stash="avoid")
             simgr.drop(stash="unsat")
             simgr.drop(stash="traced", filter_func=lambda state: not state.satisfiable())
 
-            # PART 7: debugging
+            # PART 8: debugging
             if debug:
                 name = None
                 if not elem.bs == b'':
                     num = elem.num
                     if elem.letter == 'C' and database:
                         name = database.get_name(num)
-                if len(simgr.traced) > 1:
+                if len(simgr.traced) != 1:
                     log.debug(elem.pretty(name=name) + f" (found {len(simgr.traced)})")
                 else:
                     log.debug(elem.pretty(name=name))

--- a/src_tracer/trace.py
+++ b/src_tracer/trace.py
@@ -32,7 +32,7 @@ TEST_IS_ELEM    = 0b11100000
 SET_IS_ELEM     = 0b01000000
 
 TEST_ELEM       = 0b11111111
-SET_END         = ord('L')
+SET_END         = ord('E')
 SET_RETURN      = ord('R')
 SET_RETURN_TAIL = ord('S')
 SET_FUNC_ANON   = ord('A')
@@ -46,8 +46,8 @@ SET_IF          = ord('I')
 SET_ELSE        = ord('O')
 #/* 'F' is reserved, use _TRACE_SET_ELEM2_FORK */
 SET_FORK_res    = ord('F')
-#/* 'E' is reserved, use _TRACE_SET_ELEM2_CATCH */
-SET_CATCH_res   = ord('E')
+#/* 'J' is reserved, use _TRACE_SET_ELEM2_CATCH */
+SET_CATCH_res   = ord('J')
 #/* 'D' is reserved, use _TRACE_SET_ELEM2_DATA */
 SET_DATA_res    = ord('D')
 
@@ -106,7 +106,7 @@ def letter(b, count=0):
     elif b & TEST_ELEM2 == SET_ELEM2_FORK:
         return 'F'
     elif b & TEST_ELEM2 == SET_ELEM2_CATCH:
-        return 'E'
+        return 'J'
     elif b & TEST_ELEM2 == SET_ELEM2_DATA:
         return 'D'
     raise ValueError(f"There is no letter for {bin(b)}")
@@ -185,7 +185,7 @@ class Trace:
                 # remove a leading 0
                 hexstring = hexstring[1:]
             res += elem.letter + hexstring
-            if elem.letter == 'L':
+            if elem.letter == 'E':
                 return res
         # normally, a trace should end with F0
         return res
@@ -278,7 +278,7 @@ class TraceCompact(Trace):
                 count -= 1
             else:
                 break
-            if elem.letter == 'L':
+            if elem.letter == 'E':
                 break
         if count != 0:
             raise ValueError(f"Trace ended, could not yield {count} elements")

--- a/src_tracer/trace.py
+++ b/src_tracer/trace.py
@@ -32,7 +32,7 @@ TEST_IS_ELEM    = 0b11100000
 SET_IS_ELEM     = 0b01000000
 
 TEST_ELEM       = 0b11111111
-SET_END         = ord('Q')
+SET_END         = ord('L')
 SET_RETURN      = ord('R')
 SET_RETURN_TAIL = ord('S')
 SET_FUNC_ANON   = ord('A')
@@ -185,7 +185,7 @@ class Trace:
                 # remove a leading 0
                 hexstring = hexstring[1:]
             res += elem.letter + hexstring
-            if elem.letter == 'Q':
+            if elem.letter == 'L':
                 return res
         # normally, a trace should end with F0
         return res
@@ -278,7 +278,7 @@ class TraceCompact(Trace):
                 count -= 1
             else:
                 break
-            if elem.letter == 'Q':
+            if elem.letter == 'L':
                 break
         if count != 0:
             raise ValueError(f"Trace ended, could not yield {count} elements")

--- a/src_tracer/trace.py
+++ b/src_tracer/trace.py
@@ -32,27 +32,24 @@ TEST_IS_ELEM    = 0b11100000
 SET_IS_ELEM     = 0b01000000
 
 TEST_ELEM       = 0b11111111
-SET_END         = 0b01000101 # 'E'
-SET_RETURN      = 0b01010010 # 'R'
-SET_RETURN_TAIL = 0b01001000 # 'H'
-SET_FUNC_ANON   = 0b01000001 # 'A'
-SET_TRY         = 0b01010011 # 'S'
-SET_PAUSE       = 0b01010000 # 'P'
+SET_END         = ord('Q')
+SET_RETURN      = ord('R')
+SET_RETURN_TAIL = ord('S')
+SET_FUNC_ANON   = ord('A')
+SET_TRY         = ord('T')
+SET_PAUSE       = ord('P')
 #/* FUNC_32 always comes with 4 bytes, a 32 bit function number! */
-SET_FUNC_32     = 0b01000110 # 'F'
-#/* 'T' and 'N' could be used instead of
+SET_FUNC_32     = ord('C')
+#/* 'I' and 'O' could be used instead of
 # * _TRACE_IE_BYTE_INIT for faster trace writing */
-SET_IF          = 0b01010100 # 'T'
-SET_ELSE        = 0b01001110 # 'N'
-#/* 'G' is reserved, use _TRACE_SET_FORK */
-SET_FORK_res    = 0b01000111 # 'G'
-#/* 'L' is reserved, use _TRACE_SET_CATCH */
-SET_CATCH_res   = 0b01001100 # 'L'
-#/* 'D' is reserved, use _TRACE_SET_DATA */
-SET_DATA_res    = 0b01000100 # 'D'
-#/* 'M' and 'B' are currently not supported */
-SET_FUNC_STR_res = 0b01001101 # 'M'
-SET_DATA_STR_res = 0b01000010 # 'B'
+SET_IF          = ord('I')
+SET_ELSE        = ord('O')
+#/* 'F' is reserved, use _TRACE_SET_ELEM2_FORK */
+SET_FORK_res    = ord('F')
+#/* 'E' is reserved, use _TRACE_SET_ELEM2_CATCH */
+SET_CATCH_res   = ord('E')
+#/* 'D' is reserved, use _TRACE_SET_ELEM2_DATA */
+SET_DATA_res    = ord('D')
 
 #/* 'X' to '_' are reserved */
 TEST_ELEM_res   = 0b11111000
@@ -62,9 +59,9 @@ TEST_IS_ELEM2   = 0b11100000
 SET_IS_ELEM2    = 0b01100000
 
 TEST_ELEM2      = 0b11111000
-SET_FORK        = 0b01100000
-SET_CATCH       = 0b01101000
-SET_DATA        = 0b01110000
+SET_ELEM2_FORK  = 0b01100000
+SET_ELEM2_CATCH = 0b01101000
+SET_ELEM2_DATA  = 0b01110000
 SET_ELEM2_res   = 0b01111000
 
 
@@ -99,18 +96,18 @@ byte_length = {
 def letter(b, count=0):
     if b & TEST_IE == SET_IE:
         if b & (1 << count):
-            return 'T'
+            return 'I'
         else:
-            return 'N'
+            return 'O'
     elif b & TEST_FUNC == SET_FUNC:
-        return 'F'
+        return 'C'
     elif b & TEST_IS_ELEM == SET_IS_ELEM:
         return chr(b)
-    elif b & TEST_ELEM2 == SET_FORK:
-        return 'G'
-    elif b & TEST_ELEM2 == SET_CATCH:
-        return 'L'
-    elif b & TEST_ELEM2 == SET_DATA:
+    elif b & TEST_ELEM2 == SET_ELEM2_FORK:
+        return 'F'
+    elif b & TEST_ELEM2 == SET_ELEM2_CATCH:
+        return 'E'
+    elif b & TEST_ELEM2 == SET_ELEM2_DATA:
         return 'D'
     raise ValueError(f"There is no letter for {bin(b)}")
 
@@ -188,7 +185,7 @@ class Trace:
                 # remove a leading 0
                 hexstring = hexstring[1:]
             res += elem.letter + hexstring
-            if elem.letter == 'E':
+            if elem.letter == 'Q':
                 return res
         # normally, a trace should end with F0
         return res
@@ -198,7 +195,7 @@ class Trace:
         Yield all function calls in a trace.
         """
         for elem in iter(self):
-            if elem.letter in ('F', 'S'):
+            if elem.letter in ('C', 'A'):
                 yield elem
 
 
@@ -281,7 +278,7 @@ class TraceCompact(Trace):
                 count -= 1
             else:
                 break
-            if elem.letter == 'E':
+            if elem.letter == 'Q':
                 break
         if count != 0:
             raise ValueError(f"Trace ended, could not yield {count} elements")


### PR DESCRIPTION
This changes the trace format. But not the performance, only the elements. So when observing the text trace by hand, one might find this format more readable.

- `C` for "function **C**all" (old `F`)
- `A` for "**A**nonymous function call" (same as old)
- `R` for "**R**eturn" (same)
- `S` for "**S**pecial return with **S**ibcall / tailcall" (old `H`)
- `I` for "**I**f / bit **1**" (old `T`)
- `O` for "**O**ther / bit **0**" (old `N`)
- `T` for "**T**ry / setjmp" (old `S`)
- `U` for "**U**ntry / try end" (same)
- `J` for "**J**umped into catch block / setjmp" (old `S`)
- `P` for "**P**ause" (same)
- `F` for "**F**ork" (old `G`)
- `E` for "trace **E**nd" (same)

I am unsure whether this should be merged or not. It should be much more readable, but it also makes the old trace format incomatible.